### PR TITLE
Update example to use v0.3.0 image tag and default namespace

### DIFF
--- a/examples/nvidia-vgpu-device-manager-example.yaml
+++ b/examples/nvidia-vgpu-device-manager-example.yaml
@@ -19,11 +19,11 @@ spec:
       serviceAccountName: vgpu-device-manager
       containers:
       - name: vgpu-device-manager
-        image: nvcr.io/nvidia/cloud-native/vgpu-device-manager:v0.1.0
+        image: nvcr.io/nvidia/cloud-native/vgpu-device-manager:v0.3.0
         imagePullPolicy: IfNotPresent
         env:
         - name: NAMESPACE
-          value: "gpu-operator"
+          value: "default"
         - name: NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
This change updates the vGPU device manager example deployment YAML to use:

- the current latest image tag `v0.3.0` 
- the `default` namespace env var, as the `DaemonSet` is deployed in the `default` namespace