### PR TITLE
 fix: always reschedule GPU operands after vGPU config

### DIFF
--- a/cmd/nvidia-k8s-vgpu-dm/main.go
+++ b/cmd/nvidia-k8s-vgpu-dm/main.go
@@ -374,6 +374,12 @@ func updateConfig(clientset *kubernetes.Clientset, selectedConfig string) error 
 	if err != nil {
 		return fmt.Errorf("unable to shutdown gpu operands: %v", err)
 	}
+	defer func() {
+		log.Info("Restarting all GPU operands previously shutdown in Kubernetes by enabling their component-specific nodeSelector labels")
+		if err := rescheduleGPUOperands(clientset); err != nil {
+			log.Errorf("Unable to reschedule gpu operands: %v", err)
+		}
+	}()
 
 	if err := handleMIGConfiguration(clientset, selectedConfig); err != nil {
 		return fmt.Errorf("unable to handle MIG configuration: %v", err)
@@ -383,12 +389,6 @@ func updateConfig(clientset *kubernetes.Clientset, selectedConfig string) error 
 	err = applyConfig(selectedConfig)
 	if err != nil {
 		return fmt.Errorf("unable to apply config '%s': %v", selectedConfig, err)
-	}
-
-	log.Info("Restarting all GPU operands previously shutdown in Kubernetes by enabling their component-specific nodeSelector labels")
-	err = rescheduleGPUOperands(clientset)
-	if err != nil {
-		return fmt.Errorf("unable to reschedule gpu operands: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
  ## Problem

See https://github.com/NVIDIA/vgpu-device-manager/issues/162 for context. 

TL;DR: 

  Before applying a vGPU configuration, `updateConfig()` shuts down GPU Operator components (sandbox-device-plugin, sandbox-validator) by setting their node labels to `paused-for-vgpu-change`. Previously, `rescheduleGPUOperands()` was only called at the end of `updateConfig()` on the success path. If `handleMIGConfiguration()` or `applyConfig()` failed, the function returned early without rescheduling, leaving the labels in the `paused-for-vgpu-change` state permanently.

  This caused a deadlock: the sandbox-validator never starts, so it never creates the `vgpu-manager-ready` validation file, so the vgpu-device-manager pod's init container blocks forever — even after the root cause is resolved.

  ## Fix

  Moved `rescheduleGPUOperands()` from an explicit call at the end of `updateConfig()` into a `defer` immediately after `shutdownGPUOperands()` succeeds. This guarantees operands are rescheduled on all exit paths (success, MIG config failure, vGPU apply failure).



  ## Test plan

**Setup:** 

- GPU Operator installed with `sandboxWorkloads.enabled=true`
- Node: labeled with `nvidia.com/gpu.workload.config=vm-vgpu`
- GPU: A100

 **Reproducing the bug** 

1. Set an incompatible vGPU config to force failure:
   ```
   kubectl label node <node> nvidia.com/vgpu.config=T4-1Q --overwrite
   ```
2. vgpu-device-manager fails with: `"vGPU type T4-1Q is not supported on GPU"`
3. Labels stuck at `paused-for-vgpu-change`:
   ```
   nvidia.com/gpu.deploy.sandbox-device-plugin: paused-for-vgpu-change
   nvidia.com/gpu.deploy.sandbox-validator: paused-for-vgpu-change
   nvidia.com/vgpu.config.state: failed
   ```
4. Deleting the vgpu-manager pod (simulating a driver image update) reschedules vgpu-device-manager, but sandbox pods never come back — stuck in Init forever.

## Verifying the fix

1. Deployed the fixed image via ClusterPolicy.
2. Set the same incompatible config:
   ```
   kubectl label node <node> nvidia.com/vgpu.config=T4-1Q --overwrite
   ```
3. vgpu-device-manager fails as expected, but labels are reset to `true`:
   ```
   nvidia.com/gpu.deploy.sandbox-device-plugin: true
   nvidia.com/gpu.deploy.sandbox-validator: true
   nvidia.com/vgpu.config.state: failed
   ```
4. Sandbox pods are rescheduled despite the failure — state machine is no longer stuck.
