### PR TITLE
docs: improve GetVersionParts function documentation

### DIFF
--- a/internal/info/version.go
+++ b/internal/info/version.go
@@ -25,7 +25,7 @@ var version = "unknown"
 // and will be populated by the Makefile
 var gitCommit = ""
 
-// GetVersionParts returns the different version components
+// GetVersionParts returns a string slice containing the version string and, if available, the git commit hash. The slice is intended for constructing version-related information.
 func GetVersionParts() []string {
 	v := []string{version}
 


### PR DESCRIPTION
### 问题背景
原 `GetVersionParts` 函数的文档注释较为简略，仅说明返回版本组件，没有明确描述返回的字符串切片具体内容（版本字符串和可选的 git commit 信息）及其用途，可能导致开发者在使用时产生困惑。

### 修改内容
- 修改了 `internal/info/version.go` 文件中 `GetVersionParts` 函数的注释。
- 更新后的注释更详细地说明：函数返回一个字符串切片，包含版本字符串和（如果可用）git commit 哈希；切片旨在用于构建版本相关信息。
- 这改进了代码可读性和可维护性，帮助开发者更好地理解函数行为。

### 验证方式
- 现有测试应继续通过，因为修改仅限于文档注释，没有改变任何功能代码。
- 建议运行仓库中的现有测试套件以确认无回归。

### 其他信息
- 没有 breaking changes，因为仅更新注释。
- 无需额外更新文档，此 PR 直接改进了代码内文档。
- 没有已知限制。