### PR TITLE
Add OCI standard image labels

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -75,7 +75,8 @@ jobs:
       - name: Build image
         env:
           IMAGE_NAME: ghcr.io/${LOWERCASE_REPO_OWNER}/vgpu-device-manager
-          VERSION: ${COMMIT_SHORT_SHA}-${{ matrix.arch }}
+          VERSION: ${COMMIT_SHORT_SHA}
+          IMAGE_TAG: ${COMMIT_SHORT_SHA}-${{ matrix.arch }}
           GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy-url }}
           DOCKER_BUILD_PLATFORM_OPTIONS: "--platform=linux/${{ matrix.arch }}"
         run: |

--- a/deployments/container/Dockerfile.distroless
+++ b/deployments/container/Dockerfile.distroless
@@ -51,13 +51,27 @@ COPY --from=build /artifacts/nvidia-vgpu-dm /usr/bin/nvidia-vgpu-dm
 COPY --from=build /artifacts/nvidia-k8s-vgpu-dm /usr/bin/nvidia-k8s-vgpu-dm
 COPY --from=mig-manager /usr/bin/nvidia-mig-parted /usr/bin/nvidia-mig-parted
 
+ARG VERSION
+ARG GIT_COMMIT
+ARG BUILD_TIMESTAMP
+
 LABEL version="${VERSION}"
 LABEL release="N/A"
 LABEL vendor="NVIDIA"
 LABEL io.k8s.display-name="NVIDIA vGPU Device Manager for Kubernetes"
 LABEL name="NVIDIA vGPU Device Manager for Kubernetes"
 LABEL summary="NVIDIA vGPU Device Manager for Kubernetes"
-LABEL description="See summary"
+LABEL description="Automates vGPU configuration of NVIDIA GPUs"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/distroless/go"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Automates vGPU configuration of NVIDIA GPUs"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/vgpu-device-manager.git"
+LABEL org.opencontainers.image.title="NVIDIA vGPU Device Manager for Kubernetes"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/vgpu-device-manager"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${VERSION}"
 
 USER 0:0
 ENTRYPOINT ["nvidia-k8s-vgpu-dm"]

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -26,7 +26,8 @@ endif
 GOPROXY ?= https://proxy.golang.org,direct
 
 IMAGE_VERSION := $(VERSION)
-IMAGE = $(IMAGE_NAME):$(IMAGE_VERSION)
+IMAGE_TAG ?= $(IMAGE_VERSION)
+IMAGE = $(IMAGE_NAME):$(IMAGE_TAG)
 
 OUT_IMAGE_NAME ?= $(IMAGE_NAME)
 OUT_IMAGE_VERSION ?= $(IMAGE_VERSION)
@@ -63,6 +64,7 @@ $(BUILD_TARGETS): build-%:
 		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
 		--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
 		--build-arg GOPROXY="$(GOPROXY)" \
+		--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 		--file $(DOCKERFILE) \
 		$(CURDIR)
 ifeq ($(PUSH_ON_BUILD),true)

--- a/versions.mk
+++ b/versions.mk
@@ -14,8 +14,6 @@
 
 VERSION ?= v0.4.2
 
-vVERSION := v$(VERSION:v%=%)
-
 GOLANG_VERSION := $(shell ./hack/golang-version.sh)
 
 GO_LICENSES_VERSION := v2.0.1


### PR DESCRIPTION
This PR adds well-known OCI Image labels to the vgpu-device-manager image metadata.

**Before**
```
$ docker inspect --format='{{json .Config.Labels}}' nvcr.io/nvidia/cloud-native/vgpu-device-manager:v0.4.2 | jq
{
  "description": "See summary",
  "io.k8s.display-name": "NVIDIA vGPU Device Manager for Kubernetes",
  "name": "NVIDIA vGPU Device Manager for Kubernetes",
  "org.opencontainers.image.created": "2026-03-16T23:38:54Z",
  "org.opencontainers.image.documentation": "https://developer.download.nvidia.com/distroless-oss/docs.html",
  "org.opencontainers.image.revision": "23737194f65d13d7c282e2fffa64efab18a32a59",
  "org.opencontainers.image.title": "Golang Distroless Image",
  "org.opencontainers.image.url": "https://developer.download.nvidia.com/distroless-oss/index.html",
  "org.opencontainers.image.version": "v4.0.3",
  "release": "N/A",
  "summary": "NVIDIA vGPU Device Manager for Kubernetes",
  "vendor": "NVIDIA",
  "version": ""
}
```

**After**
```
$ docker inspect --format='{{json .Config.Labels}}' ghcr.io/nvidia/vgpu-device-manager:4c40b8df | jq
{
  "description": "Automates vGPU configuration of NVIDIA GPUs",
  "io.k8s.display-name": "NVIDIA vGPU Device Manager for Kubernetes",
  "name": "NVIDIA vGPU Device Manager for Kubernetes",
  "org.opencontainers.image.base.name": "nvcr.io/nvidia/distroless/go",
  "org.opencontainers.image.created": "2026-08-17T18:38:36Z",
  "org.opencontainers.image.description": "Automates vGPU configuration of NVIDIA GPUs",
  "org.opencontainers.image.documentation": "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator",
  "org.opencontainers.image.revision": "4c40b8df5c33feda39dd4b51c81e417c136b893d",
  "org.opencontainers.image.source": "https://github.com/NVIDIA/vgpu-device-manager.git",
  "org.opencontainers.image.title": "NVIDIA vGPU Device Manager for Kubernetes",
  "org.opencontainers.image.url": "https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/vgpu-device-manager",
  "org.opencontainers.image.vendor": "NVIDIA",
  "org.opencontainers.image.version": "4c40b8df",
  "release": "N/A",
  "summary": "NVIDIA vGPU Device Manager for Kubernetes",
  "vendor": "NVIDIA",
  "version": "4c40b8df"
}
```
