### PR TITLE
Remove Go module versions from rendered TPN document

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -20,73 +20,73 @@ binary are not inventoried below.
 
 ## Dependency Index
 
-| Package | License | Module |
-|---------|---------|--------|
-| `github.com/NVIDIA/go-nvlib/pkg` | Apache-2.0 | `github.com/NVIDIA/go-nvlib@v0.12.0` |
-| `github.com/NVIDIA/go-nvml/pkg` | Apache-2.0 | `github.com/NVIDIA/go-nvml@v0.13.3-1` |
-| `github.com/NVIDIA/mig-parted` | Apache-2.0 | `github.com/NVIDIA/mig-parted@v0.14.4` |
-| `github.com/cpuguy83/go-md2man/v2/md2man` | MIT | `github.com/cpuguy83/go-md2man/v2@v2.0.7` |
-| `github.com/davecgh/go-spew/spew` | ISC | `github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc` |
-| `github.com/emicklei/go-restful/v3` | MIT | `github.com/emicklei/go-restful/v3@v3.13.0` |
-| `github.com/fxamacker/cbor/v2` | MIT | `github.com/fxamacker/cbor/v2@v2.9.0` |
-| `github.com/gabriel-vasile/mimetype` | MIT | `github.com/gabriel-vasile/mimetype@v1.4.13` |
-| `github.com/go-logr/logr` | Apache-2.0 | `github.com/go-logr/logr@v1.4.3` |
-| `github.com/go-openapi/jsonpointer` | Apache-2.0 | `github.com/go-openapi/jsonpointer@v0.21.0` |
-| `github.com/go-openapi/jsonreference` | Apache-2.0 | `github.com/go-openapi/jsonreference@v0.20.2` |
-| `github.com/go-openapi/swag` | Apache-2.0 | `github.com/go-openapi/swag@v0.23.0` |
-| `github.com/go-playground/locales` | MIT | `github.com/go-playground/locales@v0.14.1` |
-| `github.com/go-playground/universal-translator` | MIT | `github.com/go-playground/universal-translator@v0.18.1` |
-| `github.com/go-playground/validator/v10` | MIT | `github.com/go-playground/validator/v10@v10.30.3` |
-| `github.com/google/gnostic-models` | Apache-2.0 | `github.com/google/gnostic-models@v0.7.0` |
-| `github.com/google/uuid` | BSD-3-Clause | `github.com/google/uuid@v1.6.0` |
-| `github.com/josharian/intern` | MIT | `github.com/josharian/intern@v1.0.0` |
-| `github.com/json-iterator/go` | MIT | `github.com/json-iterator/go@v1.1.12` |
-| `github.com/leodido/go-urn` | MIT | `github.com/leodido/go-urn@v1.4.0` |
-| `github.com/mailru/easyjson` | MIT | `github.com/mailru/easyjson@v0.7.7` |
-| `github.com/modern-go/concurrent` | Apache-2.0 | `github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd` |
-| `github.com/modern-go/reflect2` | Apache-2.0 | `github.com/modern-go/reflect2@v1.0.3-0.20250322232337-35a7c28c31ee` |
-| `github.com/munnerz/goautoneg` | BSD-3-Clause | `github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822` |
-| `github.com/pmezard/go-difflib/difflib` | BSD-3-Clause | `github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2` |
-| `github.com/russross/blackfriday/v2` | BSD-2-Clause | `github.com/russross/blackfriday/v2@v2.1.0` |
-| `github.com/sirupsen/logrus` | MIT | `github.com/sirupsen/logrus@v1.9.4` |
-| `github.com/spf13/pflag` | BSD-3-Clause | `github.com/spf13/pflag@v1.0.9` |
-| `github.com/urfave/cli/v2` | MIT | `github.com/urfave/cli/v2@v2.27.7` |
-| `github.com/x448/float16` | MIT | `github.com/x448/float16@v0.8.4` |
-| `github.com/xrash/smetrics` | MIT | `github.com/xrash/smetrics@v0.0.0-20240521201337-686a1a2994c1` |
-| `go.yaml.in/yaml/v2` | Apache-2.0 | `go.yaml.in/yaml/v2@v2.4.3` |
-| `go.yaml.in/yaml/v3` | MIT | `go.yaml.in/yaml/v3@v3.0.4` |
-| `golang.org/x/crypto/sha3` | BSD-3-Clause | `golang.org/x/crypto@v0.52.0` |
-| `golang.org/x/net` | BSD-3-Clause | `golang.org/x/net@v0.55.0` |
-| `golang.org/x/oauth2` | BSD-3-Clause | `golang.org/x/oauth2@v0.34.0` |
-| `golang.org/x/sys` | BSD-3-Clause | `golang.org/x/sys@v0.47.0` |
-| `golang.org/x/term` | BSD-3-Clause | `golang.org/x/term@v0.43.0` |
-| `golang.org/x/text` | BSD-3-Clause | `golang.org/x/text@v0.37.0` |
-| `golang.org/x/time/rate` | BSD-3-Clause | `golang.org/x/time@v0.14.0` |
-| `google.golang.org/protobuf` | BSD-3-Clause | `google.golang.org/protobuf@v1.36.12-0.20260120151049-f2248ac996af` |
-| `gopkg.in/evanphx/json-patch.v4` | BSD-3-Clause | `gopkg.in/evanphx/json-patch.v4@v4.13.0` |
-| `gopkg.in/inf.v0` | BSD-3-Clause | `gopkg.in/inf.v0@v0.9.1` |
-| `gopkg.in/yaml.v3` | MIT | `gopkg.in/yaml.v3@v3.0.1` |
-| `k8s.io/api` | Apache-2.0 | `k8s.io/api@v0.36.3` |
-| `k8s.io/apimachinery/pkg` | Apache-2.0 | `k8s.io/apimachinery@v0.36.3` |
-| `k8s.io/apimachinery/third_party/forked/golang` | BSD-3-Clause | `k8s.io/apimachinery@v0.36.3` |
-| `k8s.io/client-go` | Apache-2.0 | `k8s.io/client-go@v0.36.3` |
-| `k8s.io/klog/v2` | Apache-2.0 | `k8s.io/klog/v2@v2.140.0` |
-| `k8s.io/kube-openapi/pkg` | Apache-2.0 | `k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a` |
-| `k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json` | BSD-3-Clause | `k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a` |
-| `k8s.io/kube-openapi/pkg/validation/spec` | Apache-2.0 | `k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a` |
-| `k8s.io/utils` | Apache-2.0 | `k8s.io/utils@v0.0.0-20260210185600-b8788abfbbc2` |
-| `k8s.io/utils/internal/third_party/forked/golang/net` | BSD-3-Clause | `k8s.io/utils@v0.0.0-20260210185600-b8788abfbbc2` |
-| `sigs.k8s.io/json` | Apache-2.0 / BSD-3-Clause | `sigs.k8s.io/json@v0.0.0-20250730193827-2d320260d730` |
-| `sigs.k8s.io/randfill` | Apache-2.0 | `sigs.k8s.io/randfill@v1.0.0` |
-| `sigs.k8s.io/structured-merge-diff/v6` | Apache-2.0 | `sigs.k8s.io/structured-merge-diff/v6@v6.3.3` |
-| `sigs.k8s.io/yaml` | Apache-2.0 / BSD-3-Clause / MIT | `sigs.k8s.io/yaml@v1.6.0` |
+| Package | License | Dependency |
+|---------|---------|------------|
+| `github.com/NVIDIA/go-nvlib/pkg` | Apache-2.0 | `github.com/NVIDIA/go-nvlib` |
+| `github.com/NVIDIA/go-nvml/pkg` | Apache-2.0 | `github.com/NVIDIA/go-nvml` |
+| `github.com/NVIDIA/mig-parted` | Apache-2.0 | `github.com/NVIDIA/mig-parted` |
+| `github.com/cpuguy83/go-md2man/v2/md2man` | MIT | `github.com/cpuguy83/go-md2man/v2` |
+| `github.com/davecgh/go-spew/spew` | ISC | `github.com/davecgh/go-spew` |
+| `github.com/emicklei/go-restful/v3` | MIT | `github.com/emicklei/go-restful/v3` |
+| `github.com/fxamacker/cbor/v2` | MIT | `github.com/fxamacker/cbor/v2` |
+| `github.com/gabriel-vasile/mimetype` | MIT | `github.com/gabriel-vasile/mimetype` |
+| `github.com/go-logr/logr` | Apache-2.0 | `github.com/go-logr/logr` |
+| `github.com/go-openapi/jsonpointer` | Apache-2.0 | `github.com/go-openapi/jsonpointer` |
+| `github.com/go-openapi/jsonreference` | Apache-2.0 | `github.com/go-openapi/jsonreference` |
+| `github.com/go-openapi/swag` | Apache-2.0 | `github.com/go-openapi/swag` |
+| `github.com/go-playground/locales` | MIT | `github.com/go-playground/locales` |
+| `github.com/go-playground/universal-translator` | MIT | `github.com/go-playground/universal-translator` |
+| `github.com/go-playground/validator/v10` | MIT | `github.com/go-playground/validator/v10` |
+| `github.com/google/gnostic-models` | Apache-2.0 | `github.com/google/gnostic-models` |
+| `github.com/google/uuid` | BSD-3-Clause | `github.com/google/uuid` |
+| `github.com/josharian/intern` | MIT | `github.com/josharian/intern` |
+| `github.com/json-iterator/go` | MIT | `github.com/json-iterator/go` |
+| `github.com/leodido/go-urn` | MIT | `github.com/leodido/go-urn` |
+| `github.com/mailru/easyjson` | MIT | `github.com/mailru/easyjson` |
+| `github.com/modern-go/concurrent` | Apache-2.0 | `github.com/modern-go/concurrent` |
+| `github.com/modern-go/reflect2` | Apache-2.0 | `github.com/modern-go/reflect2` |
+| `github.com/munnerz/goautoneg` | BSD-3-Clause | `github.com/munnerz/goautoneg` |
+| `github.com/pmezard/go-difflib/difflib` | BSD-3-Clause | `github.com/pmezard/go-difflib` |
+| `github.com/russross/blackfriday/v2` | BSD-2-Clause | `github.com/russross/blackfriday/v2` |
+| `github.com/sirupsen/logrus` | MIT | `github.com/sirupsen/logrus` |
+| `github.com/spf13/pflag` | BSD-3-Clause | `github.com/spf13/pflag` |
+| `github.com/urfave/cli/v2` | MIT | `github.com/urfave/cli/v2` |
+| `github.com/x448/float16` | MIT | `github.com/x448/float16` |
+| `github.com/xrash/smetrics` | MIT | `github.com/xrash/smetrics` |
+| `go.yaml.in/yaml/v2` | Apache-2.0 | `go.yaml.in/yaml/v2` |
+| `go.yaml.in/yaml/v3` | MIT | `go.yaml.in/yaml/v3` |
+| `golang.org/x/crypto/sha3` | BSD-3-Clause | `golang.org/x/crypto` |
+| `golang.org/x/net` | BSD-3-Clause | `golang.org/x/net` |
+| `golang.org/x/oauth2` | BSD-3-Clause | `golang.org/x/oauth2` |
+| `golang.org/x/sys` | BSD-3-Clause | `golang.org/x/sys` |
+| `golang.org/x/term` | BSD-3-Clause | `golang.org/x/term` |
+| `golang.org/x/text` | BSD-3-Clause | `golang.org/x/text` |
+| `golang.org/x/time/rate` | BSD-3-Clause | `golang.org/x/time` |
+| `google.golang.org/protobuf` | BSD-3-Clause | `google.golang.org/protobuf` |
+| `gopkg.in/evanphx/json-patch.v4` | BSD-3-Clause | `gopkg.in/evanphx/json-patch.v4` |
+| `gopkg.in/inf.v0` | BSD-3-Clause | `gopkg.in/inf.v0` |
+| `gopkg.in/yaml.v3` | MIT | `gopkg.in/yaml.v3` |
+| `k8s.io/api` | Apache-2.0 | `k8s.io/api` |
+| `k8s.io/apimachinery/pkg` | Apache-2.0 | `k8s.io/apimachinery` |
+| `k8s.io/apimachinery/third_party/forked/golang` | BSD-3-Clause | `k8s.io/apimachinery` |
+| `k8s.io/client-go` | Apache-2.0 | `k8s.io/client-go` |
+| `k8s.io/klog/v2` | Apache-2.0 | `k8s.io/klog/v2` |
+| `k8s.io/kube-openapi/pkg` | Apache-2.0 | `k8s.io/kube-openapi` |
+| `k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json` | BSD-3-Clause | `k8s.io/kube-openapi` |
+| `k8s.io/kube-openapi/pkg/validation/spec` | Apache-2.0 | `k8s.io/kube-openapi` |
+| `k8s.io/utils` | Apache-2.0 | `k8s.io/utils` |
+| `k8s.io/utils/internal/third_party/forked/golang/net` | BSD-3-Clause | `k8s.io/utils` |
+| `sigs.k8s.io/json` | Apache-2.0 / BSD-3-Clause | `sigs.k8s.io/json` |
+| `sigs.k8s.io/randfill` | Apache-2.0 | `sigs.k8s.io/randfill` |
+| `sigs.k8s.io/structured-merge-diff/v6` | Apache-2.0 | `sigs.k8s.io/structured-merge-diff/v6` |
+| `sigs.k8s.io/yaml` | Apache-2.0 / BSD-3-Clause / MIT | `sigs.k8s.io/yaml` |
 
 ## Dependency License Texts
 
 ### github.com/NVIDIA/go-nvlib/pkg
 
 * License: Apache-2.0
-* Module: github.com/NVIDIA/go-nvlib@v0.12.0
+* Module: github.com/NVIDIA/go-nvlib
 
 #### LICENSE
 
@@ -310,7 +310,7 @@ the PCI ID Project at https://pci-ids.ucw.cz/.
 ### github.com/NVIDIA/go-nvml/pkg
 
 * License: Apache-2.0
-* Module: github.com/NVIDIA/go-nvml@v0.13.3-1
+* Module: github.com/NVIDIA/go-nvml
 
 #### LICENSE
 
@@ -524,7 +524,7 @@ the PCI ID Project at https://pci-ids.ucw.cz/.
 ### github.com/NVIDIA/mig-parted
 
 * License: Apache-2.0
-* Module: github.com/NVIDIA/mig-parted@v0.14.4
+* Module: github.com/NVIDIA/mig-parted
 
 #### LICENSE
 
@@ -738,7 +738,7 @@ the PCI ID Project at https://pci-ids.ucw.cz/.
 ### github.com/cpuguy83/go-md2man/v2/md2man
 
 * License: MIT
-* Module: github.com/cpuguy83/go-md2man/v2@v2.0.7
+* Module: github.com/cpuguy83/go-md2man/v2
 
 #### LICENSE.md
 
@@ -771,7 +771,7 @@ SOFTWARE.
 ### github.com/davecgh/go-spew/spew
 
 * License: ISC
-* Module: github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc
+* Module: github.com/davecgh/go-spew
 
 #### LICENSE
 
@@ -798,7 +798,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ### github.com/emicklei/go-restful/v3
 
 * License: MIT
-* Module: github.com/emicklei/go-restful/v3@v3.13.0
+* Module: github.com/emicklei/go-restful/v3
 
 #### LICENSE
 
@@ -831,7 +831,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ### github.com/fxamacker/cbor/v2
 
 * License: MIT
-* Module: github.com/fxamacker/cbor/v2@v2.9.0
+* Module: github.com/fxamacker/cbor/v2
 
 #### LICENSE
 
@@ -863,7 +863,7 @@ SOFTWARE.
 ### github.com/gabriel-vasile/mimetype
 
 * License: MIT
-* Module: github.com/gabriel-vasile/mimetype@v1.4.13
+* Module: github.com/gabriel-vasile/mimetype
 
 #### LICENSE
 
@@ -896,7 +896,7 @@ SOFTWARE.
 ### github.com/go-logr/logr
 
 * License: Apache-2.0
-* Module: github.com/go-logr/logr@v1.4.3
+* Module: github.com/go-logr/logr
 
 #### LICENSE
 
@@ -1109,7 +1109,7 @@ SOFTWARE.
 ### github.com/go-openapi/jsonpointer
 
 * License: Apache-2.0
-* Module: github.com/go-openapi/jsonpointer@v0.21.0
+* Module: github.com/go-openapi/jsonpointer
 
 #### LICENSE
 
@@ -1323,7 +1323,7 @@ SOFTWARE.
 ### github.com/go-openapi/jsonreference
 
 * License: Apache-2.0
-* Module: github.com/go-openapi/jsonreference@v0.20.2
+* Module: github.com/go-openapi/jsonreference
 
 #### LICENSE
 
@@ -1537,7 +1537,7 @@ SOFTWARE.
 ### github.com/go-openapi/swag
 
 * License: Apache-2.0
-* Module: github.com/go-openapi/swag@v0.23.0
+* Module: github.com/go-openapi/swag
 
 #### LICENSE
 
@@ -1751,7 +1751,7 @@ SOFTWARE.
 ### github.com/go-playground/locales
 
 * License: MIT
-* Module: github.com/go-playground/locales@v0.14.1
+* Module: github.com/go-playground/locales
 
 #### LICENSE
 
@@ -1783,7 +1783,7 @@ SOFTWARE.
 ### github.com/go-playground/universal-translator
 
 * License: MIT
-* Module: github.com/go-playground/universal-translator@v0.18.1
+* Module: github.com/go-playground/universal-translator
 
 #### LICENSE
 
@@ -1816,7 +1816,7 @@ SOFTWARE.
 ### github.com/go-playground/validator/v10
 
 * License: MIT
-* Module: github.com/go-playground/validator/v10@v10.30.3
+* Module: github.com/go-playground/validator/v10
 
 #### LICENSE
 
@@ -1850,7 +1850,7 @@ SOFTWARE.
 ### github.com/google/gnostic-models
 
 * License: Apache-2.0
-* Module: github.com/google/gnostic-models@v0.7.0
+* Module: github.com/google/gnostic-models
 
 #### LICENSE
 
@@ -2065,7 +2065,7 @@ SOFTWARE.
 ### github.com/google/uuid
 
 * License: BSD-3-Clause
-* Module: github.com/google/uuid@v1.6.0
+* Module: github.com/google/uuid
 
 #### LICENSE
 
@@ -2104,7 +2104,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### github.com/josharian/intern
 
 * License: MIT
-* Module: github.com/josharian/intern@v1.0.0
+* Module: github.com/josharian/intern
 
 #### license.md
 
@@ -2137,7 +2137,7 @@ SOFTWARE.
 ### github.com/json-iterator/go
 
 * License: MIT
-* Module: github.com/json-iterator/go@v1.1.12
+* Module: github.com/json-iterator/go
 
 #### LICENSE
 
@@ -2170,7 +2170,7 @@ SOFTWARE.
 ### github.com/leodido/go-urn
 
 * License: MIT
-* Module: github.com/leodido/go-urn@v1.4.0
+* Module: github.com/leodido/go-urn
 
 #### LICENSE
 
@@ -2203,7 +2203,7 @@ SOFTWARE.
 ### github.com/mailru/easyjson
 
 * License: MIT
-* Module: github.com/mailru/easyjson@v0.7.7
+* Module: github.com/mailru/easyjson
 
 #### LICENSE
 
@@ -2222,7 +2222,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ### github.com/modern-go/concurrent
 
 * License: Apache-2.0
-* Module: github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd
+* Module: github.com/modern-go/concurrent
 
 #### LICENSE
 
@@ -2435,7 +2435,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ### github.com/modern-go/reflect2
 
 * License: Apache-2.0
-* Module: github.com/modern-go/reflect2@v1.0.3-0.20250322232337-35a7c28c31ee
+* Module: github.com/modern-go/reflect2
 
 #### LICENSE
 
@@ -2648,7 +2648,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ### github.com/munnerz/goautoneg
 
 * License: BSD-3-Clause
-* Module: github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822
+* Module: github.com/munnerz/goautoneg
 
 #### LICENSE
 
@@ -2691,7 +2691,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### github.com/pmezard/go-difflib/difflib
 
 * License: BSD-3-Clause
-* Module: github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2
+* Module: github.com/pmezard/go-difflib
 
 #### LICENSE
 
@@ -2730,7 +2730,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### github.com/russross/blackfriday/v2
 
 * License: BSD-2-Clause
-* Module: github.com/russross/blackfriday/v2@v2.1.0
+* Module: github.com/russross/blackfriday/v2
 
 #### LICENSE.txt
 
@@ -2771,7 +2771,7 @@ Blackfriday is distributed under the Simplified BSD License:
 ### github.com/sirupsen/logrus
 
 * License: MIT
-* Module: github.com/sirupsen/logrus@v1.9.4
+* Module: github.com/sirupsen/logrus
 
 #### LICENSE
 
@@ -2804,7 +2804,7 @@ THE SOFTWARE.
 ### github.com/spf13/pflag
 
 * License: BSD-3-Clause
-* Module: github.com/spf13/pflag@v1.0.9
+* Module: github.com/spf13/pflag
 
 #### LICENSE
 
@@ -2844,7 +2844,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### github.com/urfave/cli/v2
 
 * License: MIT
-* Module: github.com/urfave/cli/v2@v2.27.7
+* Module: github.com/urfave/cli/v2
 
 #### LICENSE
 
@@ -2877,7 +2877,7 @@ SOFTWARE.
 ### github.com/x448/float16
 
 * License: MIT
-* Module: github.com/x448/float16@v0.8.4
+* Module: github.com/x448/float16
 
 #### LICENSE
 
@@ -2911,7 +2911,7 @@ SOFTWARE.
 ### github.com/xrash/smetrics
 
 * License: MIT
-* Module: github.com/xrash/smetrics@v0.0.0-20240521201337-686a1a2994c1
+* Module: github.com/xrash/smetrics
 
 #### LICENSE
 
@@ -2944,7 +2944,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ### go.yaml.in/yaml/v2
 
 * License: Apache-2.0
-* Module: go.yaml.in/yaml/v2@v2.4.3
+* Module: go.yaml.in/yaml/v2
 
 #### LICENSE
 
@@ -3176,7 +3176,7 @@ limitations under the License.
 ### go.yaml.in/yaml/v3
 
 * License: MIT
-* Module: go.yaml.in/yaml/v3@v3.0.4
+* Module: go.yaml.in/yaml/v3
 
 #### LICENSE
 
@@ -3257,7 +3257,7 @@ limitations under the License.
 ### golang.org/x/crypto/sha3
 
 * License: BSD-3-Clause
-* Module: golang.org/x/crypto@v0.52.0
+* Module: golang.org/x/crypto
 
 #### LICENSE
 
@@ -3296,7 +3296,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### golang.org/x/net
 
 * License: BSD-3-Clause
-* Module: golang.org/x/net@v0.55.0
+* Module: golang.org/x/net
 
 #### LICENSE
 
@@ -3335,7 +3335,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### golang.org/x/oauth2
 
 * License: BSD-3-Clause
-* Module: golang.org/x/oauth2@v0.34.0
+* Module: golang.org/x/oauth2
 
 #### LICENSE
 
@@ -3374,7 +3374,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### golang.org/x/sys
 
 * License: BSD-3-Clause
-* Module: golang.org/x/sys@v0.47.0
+* Module: golang.org/x/sys
 
 #### LICENSE
 
@@ -3413,7 +3413,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### golang.org/x/term
 
 * License: BSD-3-Clause
-* Module: golang.org/x/term@v0.43.0
+* Module: golang.org/x/term
 
 #### LICENSE
 
@@ -3452,7 +3452,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### golang.org/x/text
 
 * License: BSD-3-Clause
-* Module: golang.org/x/text@v0.37.0
+* Module: golang.org/x/text
 
 #### LICENSE
 
@@ -3491,7 +3491,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### golang.org/x/time/rate
 
 * License: BSD-3-Clause
-* Module: golang.org/x/time@v0.14.0
+* Module: golang.org/x/time
 
 #### LICENSE
 
@@ -3530,7 +3530,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### google.golang.org/protobuf
 
 * License: BSD-3-Clause
-* Module: google.golang.org/protobuf@v1.36.12-0.20260120151049-f2248ac996af
+* Module: google.golang.org/protobuf
 
 #### LICENSE
 
@@ -3569,7 +3569,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### gopkg.in/evanphx/json-patch.v4
 
 * License: BSD-3-Clause
-* Module: gopkg.in/evanphx/json-patch.v4@v4.13.0
+* Module: gopkg.in/evanphx/json-patch.v4
 
 #### LICENSE
 
@@ -3606,7 +3606,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### gopkg.in/inf.v0
 
 * License: BSD-3-Clause
-* Module: gopkg.in/inf.v0@v0.9.1
+* Module: gopkg.in/inf.v0
 
 #### LICENSE
 
@@ -3646,7 +3646,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### gopkg.in/yaml.v3
 
 * License: MIT
-* Module: gopkg.in/yaml.v3@v3.0.1
+* Module: gopkg.in/yaml.v3
 
 #### LICENSE
 
@@ -3727,7 +3727,7 @@ limitations under the License.
 ### k8s.io/api
 
 * License: Apache-2.0
-* Module: k8s.io/api@v0.36.3
+* Module: k8s.io/api
 
 #### LICENSE
 
@@ -3941,7 +3941,7 @@ limitations under the License.
 ### k8s.io/apimachinery/pkg
 
 * License: Apache-2.0
-* Module: k8s.io/apimachinery@v0.36.3
+* Module: k8s.io/apimachinery
 
 #### LICENSE
 
@@ -4155,7 +4155,7 @@ limitations under the License.
 ### k8s.io/apimachinery/third_party/forked/golang
 
 * License: BSD-3-Clause
-* Module: k8s.io/apimachinery@v0.36.3
+* Module: k8s.io/apimachinery
 
 #### LICENSE
 
@@ -4194,7 +4194,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### k8s.io/client-go
 
 * License: Apache-2.0
-* Module: k8s.io/client-go@v0.36.3
+* Module: k8s.io/client-go
 
 #### LICENSE
 
@@ -4408,7 +4408,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### k8s.io/klog/v2
 
 * License: Apache-2.0
-* Module: k8s.io/klog/v2@v2.140.0
+* Module: k8s.io/klog/v2
 
 #### LICENSE
 
@@ -4611,7 +4611,7 @@ third-party archives.
 ### k8s.io/kube-openapi/pkg
 
 * License: Apache-2.0
-* Module: k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a
+* Module: k8s.io/kube-openapi
 
 #### LICENSE
 
@@ -4825,7 +4825,7 @@ third-party archives.
 ### k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json
 
 * License: BSD-3-Clause
-* Module: k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a
+* Module: k8s.io/kube-openapi
 
 #### LICENSE
 
@@ -4864,7 +4864,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### k8s.io/kube-openapi/pkg/validation/spec
 
 * License: Apache-2.0
-* Module: k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a
+* Module: k8s.io/kube-openapi
 
 #### LICENSE
 
@@ -5078,7 +5078,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### k8s.io/utils
 
 * License: Apache-2.0
-* Module: k8s.io/utils@v0.0.0-20260210185600-b8788abfbbc2
+* Module: k8s.io/utils
 
 #### LICENSE
 
@@ -5292,7 +5292,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### k8s.io/utils/internal/third_party/forked/golang/net
 
 * License: BSD-3-Clause
-* Module: k8s.io/utils@v0.0.0-20260210185600-b8788abfbbc2
+* Module: k8s.io/utils
 
 #### LICENSE
 
@@ -5331,7 +5331,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### sigs.k8s.io/json
 
 * License: Apache-2.0 / BSD-3-Clause
-* Module: sigs.k8s.io/json@v0.0.0-20250730193827-2d320260d730
+* Module: sigs.k8s.io/json
 
 #### LICENSE
 
@@ -5581,7 +5581,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### sigs.k8s.io/randfill
 
 * License: Apache-2.0
-* Module: sigs.k8s.io/randfill@v1.0.0
+* Module: sigs.k8s.io/randfill
 
 #### LICENSE
 
@@ -5825,7 +5825,7 @@ Submitted on behalf of a third-party: @disconnect3d (Disconnect3d)
 ### sigs.k8s.io/structured-merge-diff/v6
 
 * License: Apache-2.0
-* Module: sigs.k8s.io/structured-merge-diff/v6@v6.3.3
+* Module: sigs.k8s.io/structured-merge-diff/v6
 
 #### LICENSE
 
@@ -6038,7 +6038,7 @@ Submitted on behalf of a third-party: @disconnect3d (Disconnect3d)
 ### sigs.k8s.io/yaml
 
 * License: Apache-2.0 / BSD-3-Clause / MIT
-* Module: sigs.k8s.io/yaml@v1.6.0
+* Module: sigs.k8s.io/yaml
 
 #### LICENSE
 

--- a/hack/generate-third-party-notices.sh
+++ b/hack/generate-third-party-notices.sh
@@ -184,7 +184,7 @@ collapse_index() {
     '
 }
 
-# Rows carry module@version, not a URL: in vendor mode go-licenses points into
+# Rows carry module paths, not a URL: in vendor mode go-licenses points into
 # this repo at HEAD, which stops describing released content once main moves.
 # Longest-prefix match, because a license may sit below the module root.
 annotate_modules() {
@@ -196,7 +196,7 @@ annotate_modules() {
                 split(line, f, " ")
                 # "# <path> <version>", optionally "=> <path> <version>". The
                 # replacement is what is vendored; a filesystem replace has no
-                # version, so stop rather than misstate it.
+                # stable module identity, so stop rather than misattribute it.
                 if (f[4] == "=>" || f[3] == "=>") {
                     r = (f[4] == "=>") ? 5 : 4
                     if (f[r + 1] == "") {
@@ -205,10 +205,10 @@ annotate_modules() {
                         exit 1
                     }
                     mods[++m] = f[2]
-                    disp[f[2]] = f[r] "@" f[r + 1]
+                    disp[f[2]] = f[r]
                 } else {
                     mods[++m] = f[2]
-                    disp[f[2]] = f[2] "@" f[3]
+                    disp[f[2]] = f[2]
                 }
             }
             close(modfile)
@@ -245,7 +245,7 @@ build_indexes() {
     fi
 
     if cut -d, -f4 "${INDEX_FILE}" | LC_ALL=C grep -qx 'unknown'; then
-        die "could not resolve module@version for some packages from ${MODULES_TXT}." \
+        die "could not resolve a dependency for some packages from ${MODULES_TXT}." \
             "Run 'go mod tidy && go mod vendor' and re-run, rather than committing a file" \
             "with unattributed entries."
     fi
@@ -266,8 +266,8 @@ license_files_for() {
 
 emit_index_table() {
     local index="$1" pkg _url license module
-    printf '| Package | License | Module |\n'
-    printf '|---------|---------|--------|\n'
+    printf '| Package | License | Dependency |\n'
+    printf '|---------|---------|------------|\n'
 
     while IFS=, read -r pkg _url license module; do
         [[ -z "${pkg}" ]] && continue


### PR DESCRIPTION
This change edits the generate-third-party-notices.sh script to omit go-module verisons from the rendered TPN doc. It also regenerates the TPN doc.