### PR TITLE
ignore cooldown for nvidia released images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,6 @@ updates:
     - "/deployments/devel"
     schedule:
       interval: "daily"
+    cooldown:
+      exclude:
+      - nvidia/*


### PR DESCRIPTION
This was skipped before: https://github.com/NVIDIA/vgpu-device-manager/blob/7e736903a79c319edf6737eec9559826457e2ff6/deployments/container/Dockerfile.distroless#L28