### PR TITLE
Make update config little more resilent to intermittent failures

### DIFF
--- a/cmd/nvidia-k8s-vgpu-dm/main.go
+++ b/cmd/nvidia-k8s-vgpu-dm/main.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
 	migpartedv1 "github.com/NVIDIA/mig-parted/api/spec/v1"
 
@@ -73,14 +74,68 @@ var (
 	gpuClientsFileFlag             string
 	withRebootFlag                 bool
 	withShutdownHostGPUClientsFlag bool
-
-	pluginDeployed    string
-	validatorDeployed string
 )
 
 type GPUClients struct {
 	Version         string   `json:"version"          yaml:"version"`
 	SystemdServices []string `json:"systemd-services" yaml:"systemd-services"`
+}
+
+type configOperations interface {
+	assertValid(string) error
+	assertApplied(string) error
+	apply(string) error
+	configureMIG(string) error
+	waitForOperandShutdown(context.Context, string) error
+}
+
+type defaultConfigOperations struct {
+	clientset kubernetes.Interface
+	nodeName  string
+	namespace string
+}
+
+func (o *defaultConfigOperations) assertValid(config string) error {
+	return assertValidConfig(config)
+}
+
+func (o *defaultConfigOperations) assertApplied(config string) error {
+	return assertConfig(config)
+}
+
+func (o *defaultConfigOperations) apply(config string) error {
+	return applyConfig(config)
+}
+
+func (o *defaultConfigOperations) configureMIG(config string) error {
+	return handleMIGConfiguration(o.clientset, config)
+}
+
+func (o *defaultConfigOperations) waitForOperandShutdown(ctx context.Context, labelSelector string) error {
+	return waitForPodDeletion(ctx, o.clientset, o.namespace, metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", o.nodeName),
+		LabelSelector: labelSelector,
+	})
+}
+
+type configReconciler struct {
+	clientset         kubernetes.Interface
+	operations        configOperations
+	defaultVGPUConfig string
+	nodeName          string
+}
+
+func newConfigReconciler(clientset kubernetes.Interface) *configReconciler {
+	return &configReconciler{
+		clientset: clientset,
+		operations: &defaultConfigOperations{
+			clientset: clientset,
+			nodeName:  nodeNameFlag,
+			namespace: namespaceFlag,
+		},
+		defaultVGPUConfig: defaultVGPUConfigFlag,
+		nodeName:          nodeNameFlag,
+	}
 }
 
 // SyncableVGPUConfig is used to synchronize on changes to a configuration value.
@@ -267,6 +322,7 @@ func start(c *cli.Context) error {
 	}
 
 	vGPUConfig := NewSyncableVGPUConfig()
+	reconciler := newConfigReconciler(clientset)
 
 	stop := continuouslySyncVGPUConfigChanges(clientset, vGPUConfig)
 	defer close(stop)
@@ -285,32 +341,78 @@ func start(c *cli.Context) error {
 		selectedConfig = vGPUConfig.Get()
 	}
 
-	log.Infof("Updating to vGPU config: %s", selectedConfig)
-	err = updateConfig(clientset, selectedConfig)
-	if err != nil {
-		log.Errorf("Failed to apply vGPU config: %v", err)
-	} else {
-		log.Infof("Successfully updated to vGPU config: %s", selectedConfig)
+	retryBackoff := wait.Backoff{
+		Duration: 2 * time.Second,
+		Factor:   2,
+		Jitter:   0.1,
+		Steps:    4,
+		Cap:      15 * time.Second,
 	}
-	vGPUConfigStateValue := getVGPUConfigStateValue(err)
-	log.Infof("Setting node label: %s=%s", vGPUConfigStateLabel, vGPUConfigStateValue)
-	_ = setNodeLabelValue(clientset, vGPUConfigStateLabel, vGPUConfigStateValue)
-
-	// Watch for configuration changes
 	for {
-		log.Infof("Waiting for change to '%s' label", vGPUConfigLabel)
-		value := vGPUConfig.Get()
-		log.Infof("Updating to vGPU config: %s", value)
-		err = updateConfig(clientset, value)
+		log.Infof("Updating to vGPU config: %s", selectedConfig)
+		selectedConfig, err = updateConfigWithRetry(c.Context, reconciler, selectedConfig, retryBackoff)
 		if err != nil {
 			log.Errorf("Failed to apply vGPU config: %v", err)
 		} else {
-			log.Infof("Successfully updated to vGPU config: %s", value)
+			log.Infof("Successfully updated to vGPU config: %s", selectedConfig)
 		}
-		vGPUConfigStateValue = getVGPUConfigStateValue(err)
+		vGPUConfigStateValue := getVGPUConfigStateValue(err)
 		log.Infof("Setting node label: %s=%s", vGPUConfigStateLabel, vGPUConfigStateValue)
 		_ = setNodeLabelValue(clientset, vGPUConfigStateLabel, vGPUConfigStateValue)
+		if c.Err() != nil {
+			return c.Err()
+		}
+		if isRetryableConfigError(err) {
+			log.Error("Retryable vGPU configuration error persisted after bounded retries")
+			return err
+		}
+
+		log.Infof("Waiting for change to '%s' label", vGPUConfigLabel)
+		selectedConfig = vGPUConfig.Get()
 	}
+}
+
+func updateConfigWithRetry(
+	ctx context.Context,
+	reconciler *configReconciler,
+	selectedConfig string,
+	backoff wait.Backoff,
+) (string, error) {
+	var lastErr error
+	attempt := 0
+
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		attempt++
+		if attempt > 1 {
+			currentConfig, err := getNodeLabelValueForNode(ctx, reconciler.clientset, reconciler.nodeName, vGPUConfigLabel)
+			if err != nil {
+				lastErr = newRetryableConfigError(fmt.Errorf("unable to re-read vGPU config before retry: %w", err))
+				return false, nil
+			}
+			if currentConfig == "" {
+				currentConfig = reconciler.defaultVGPUConfig
+			}
+			selectedConfig = currentConfig
+			log.Infof("Retrying with current desired vGPU config: %s", selectedConfig)
+		}
+
+		lastErr = reconciler.updateConfig(ctx, selectedConfig)
+		if lastErr == nil || !isRetryableConfigError(lastErr) {
+			return true, nil
+		}
+
+		log.Warnf("Retryable vGPU configuration error on attempt %d of %d: %v", attempt, backoff.Steps, lastErr)
+		return false, nil
+	})
+	if err != nil {
+		if ctx.Err() != nil {
+			return selectedConfig, ctx.Err()
+		}
+		if !wait.Interrupted(err) {
+			return selectedConfig, err
+		}
+	}
+	return selectedConfig, lastErr
 }
 
 func continuouslySyncVGPUConfigChanges(clientset *kubernetes.Clientset, vGPUConfig *SyncableVGPUConfig) chan struct{} {
@@ -344,51 +446,71 @@ func continuouslySyncVGPUConfigChanges(clientset *kubernetes.Clientset, vGPUConf
 	return stop
 }
 
-func updateConfig(clientset *kubernetes.Clientset, selectedConfig string) error {
-
+func (r *configReconciler) updateConfig(ctx context.Context, selectedConfig string) (returnErr error) {
 	log.Info("Asserting that the requested configuration is present in the configuration file")
-	err := assertValidConfig(selectedConfig)
+	err := r.operations.assertValid(selectedConfig)
 	if err != nil {
 		return fmt.Errorf("unable to validate the selected vGPU configuration")
 	}
 
 	log.Info("Checking if the selected vGPU device configuration is currently applied or not")
-	err = assertConfig(selectedConfig)
+	err = r.operations.assertApplied(selectedConfig)
 	if err == nil {
+		log.Info("Restoring any GPU operands left paused by an interrupted vGPU configuration change")
+		if err := restoreGPUOperandLabels(ctx, r.clientset, r.nodeName, true, true); err != nil {
+			return newRetryableConfigError(fmt.Errorf("unable to recover paused GPU operands: %w", err))
+		}
 		return nil
 	}
 
-	err = getNodeStateLabels(clientset)
-	if err != nil {
-		return fmt.Errorf("unable to get node state labels: %v", err)
-	}
-
 	log.Infof("Setting node label: %s=pending", vGPUConfigStateLabel)
-	err = setNodeLabelValue(clientset, vGPUConfigStateLabel, "pending")
+	err = setNodeLabelValueForNode(ctx, r.clientset, r.nodeName, vGPUConfigStateLabel, "pending")
 	if err != nil {
-		return fmt.Errorf("error setting vGPU config state label: %v", err)
+		return newRetryableConfigError(fmt.Errorf("error setting vGPU config state label: %w", err))
 	}
 
 	log.Info("Shutting down all GPU operands in Kubernetes by disabling their component-specific nodeSelector labels")
-	err = shutdownGPUOperands(clientset)
+	_, err = r.shutdownGPUOperands(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to shutdown gpu operands: %v", err)
+		return fmt.Errorf("unable to shutdown GPU operands: %w", err)
 	}
 	defer func() {
-		log.Info("Restarting all GPU operands previously shutdown in Kubernetes by enabling their component-specific nodeSelector labels")
-		if err := rescheduleGPUOperands(clientset); err != nil {
-			log.Errorf("Unable to reschedule gpu operands: %v", err)
+		log.Info("Restarting GPU operands paused for the vGPU configuration change")
+		if err := restoreGPUOperandLabels(ctx, r.clientset, r.nodeName, true, true); err != nil {
+			restoreErr := fmt.Errorf("unable to restore GPU operands: %w", err)
+			if returnErr != nil {
+				restoreErr = fmt.Errorf("%w; %w", returnErr, restoreErr)
+			}
+			returnErr = newRetryableConfigError(restoreErr)
 		}
 	}()
 
-	if err := handleMIGConfiguration(clientset, selectedConfig); err != nil {
-		return fmt.Errorf("unable to handle MIG configuration: %v", err)
+	if err := r.operations.configureMIG(selectedConfig); err != nil {
+		return fmt.Errorf("unable to handle MIG configuration: %w", err)
 	}
 
 	log.Info("Applying the selected vGPU device configuration to the node")
-	err = applyConfig(selectedConfig)
+	err = r.operations.apply(selectedConfig)
 	if err != nil {
-		return fmt.Errorf("unable to apply config '%s': %v", selectedConfig, err)
+		return fmt.Errorf("unable to apply config %q: %w", selectedConfig, err)
+	}
+
+	log.Info("Verifying that the selected vGPU device configuration was applied")
+	if err := r.operations.assertApplied(selectedConfig); err != nil {
+		return fmt.Errorf("applied vGPU configuration %q does not match the requested configuration: %w", selectedConfig, err)
+	}
+
+	currentConfig, err := getNodeLabelValueForNode(ctx, r.clientset, r.nodeName, vGPUConfigLabel)
+	if err != nil {
+		return newRetryableConfigError(fmt.Errorf("unable to re-read vGPU config label before restoring GPU operands: %w", err))
+	}
+	if currentConfig == "" {
+		currentConfig = r.defaultVGPUConfig
+	}
+	if currentConfig != selectedConfig {
+		return newRetryableConfigError(
+			fmt.Errorf("vGPU config changed from %q to %q while applying it", selectedConfig, currentConfig),
+		)
 	}
 
 	return nil
@@ -439,70 +561,45 @@ func getVGPUConfigStateValue(err error) string {
 	return "success"
 }
 
-func getNodeStateLabels(clientset *kubernetes.Clientset) error {
-	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeNameFlag, metav1.GetOptions{})
+func (r *configReconciler) shutdownGPUOperands(ctx context.Context) (operandPauseResult, error) {
+	pauseResult, err := pauseGPUOperandLabels(ctx, r.clientset, r.nodeName)
 	if err != nil {
-		return fmt.Errorf("unable to get node object: %v", err)
+		return operandPauseResult{}, newRetryableConfigError(err)
 	}
-	labels := node.GetLabels()
 
-	log.Infof("Getting current value of '%s' node label", pluginStateLabel)
-	pluginDeployed = labels[pluginStateLabel]
-	log.Infof("Current value of '%s=%s'", pluginStateLabel, pluginDeployed)
+	log.Info("Waiting for sandbox-device-plugin to shutdown")
+	err = r.operations.waitForOperandShutdown(ctx, "app=nvidia-sandbox-device-plugin-daemonset")
+	if err == nil {
+		log.Info("Waiting for sandbox-validator to shutdown")
+		err = r.operations.waitForOperandShutdown(ctx, "app=nvidia-sandbox-validator")
+	}
+	if err == nil {
+		return pauseResult, nil
+	}
 
-	log.Infof("Getting current value of '%s' node label", validatorStateLabel)
-	validatorDeployed = labels[validatorStateLabel]
-	log.Infof("Current value of '%s=%s'", validatorStateLabel, validatorDeployed)
+	// If this process acquired the pause, no hardware operation has started and
+	// both labels can be rolled back. If the pause predated this process, the
+	// hardware state is unknown and the device plugin must remain paused.
+	restorePlugin := !pauseResult.recovering()
+	if restoreErr := restoreGPUOperandLabels(ctx, r.clientset, r.nodeName, restorePlugin, true); restoreErr != nil {
+		return pauseResult, newRetryableConfigError(
+			fmt.Errorf("GPU operand shutdown failed: %w; unable to roll back operand labels: %w", err, restoreErr),
+		)
+	}
 
-	return nil
+	return pauseResult, newRetryableConfigError(fmt.Errorf("GPU operand shutdown failed: %w", err))
 }
 
-func shutdownGPUOperands(clientset *kubernetes.Clientset) error {
-	// shutdown components by updating their respective state labels.
-	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeNameFlag, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("unable to get node object: %v", err)
-	}
-	labels := node.GetLabels()
-
-	pluginDeployed = maybeSetPaused(pluginDeployed)
-	validatorDeployed = maybeSetPaused(validatorDeployed)
-	labels[pluginStateLabel] = pluginDeployed
-	labels[validatorStateLabel] = validatorDeployed
-
-	node.SetLabels(labels)
-	_, err = clientset.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("unable to update node object: %v", err)
-	}
-
-	// wait for pods to be deleted
-	log.Infof("Waiting for sandbox-device-plugin to shutdown")
-	err = waitForPodDeletion(clientset, metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeNameFlag),
-		LabelSelector: "app=nvidia-sandbox-device-plugin-daemonset",
-	})
-	if err != nil {
-		return fmt.Errorf("error shutting down sandbox-device-plugin: %v", err)
-	}
-
-	log.Infof("Waiting for sandbox-validator to shutdown")
-	err = waitForPodDeletion(clientset, metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeNameFlag),
-		LabelSelector: "app=nvidia-sandbox-validator",
-	})
-	if err != nil {
-		return fmt.Errorf("error shutting down sandbox-validator: %v", err)
-	}
-
-	return nil
-}
-
-func waitForPodDeletion(clientset *kubernetes.Clientset, listOpts metav1.ListOptions) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+func waitForPodDeletion(
+	parent context.Context,
+	clientset kubernetes.Interface,
+	namespace string,
+	listOpts metav1.ListOptions,
+) error {
+	ctx, cancel := context.WithTimeout(parent, 120*time.Second)
 	defer cancel()
 	pollFunc := func(context.Context) (bool, error) {
-		podList, err := clientset.CoreV1().Pods(namespaceFlag).List(ctx, listOpts)
+		podList, err := clientset.CoreV1().Pods(namespace).List(ctx, listOpts)
 		if apierrors.IsNotFound(err) {
 			log.Infof("Pod was already deleted")
 			return true, nil
@@ -524,41 +621,17 @@ func waitForPodDeletion(clientset *kubernetes.Clientset, listOpts metav1.ListOpt
 	return nil
 }
 
-func rescheduleGPUOperands(clientset *kubernetes.Clientset) error {
-	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeNameFlag, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("unable to get node object: %v", err)
-	}
-	labels := node.GetLabels()
-
-	labels[pluginStateLabel] = maybeSetTrue(pluginDeployed)
-	labels[validatorStateLabel] = maybeSetTrue(validatorDeployed)
-
-	node.SetLabels(labels)
-	_, err = clientset.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("unable to update node object: %v", err)
-	}
-
-	return nil
+func getNodeLabelValue(clientset kubernetes.Interface, label string) (string, error) {
+	return getNodeLabelValueForNode(context.TODO(), clientset, nodeNameFlag, label)
 }
 
-func maybeSetPaused(currentValue string) string {
-	if currentValue == "false" || currentValue == "" {
-		return currentValue
-	}
-	return "paused-for-vgpu-change"
-}
-
-func maybeSetTrue(currentValue string) string {
-	if currentValue == "false" || currentValue == "" {
-		return currentValue
-	}
-	return "true"
-}
-
-func getNodeLabelValue(clientset *kubernetes.Clientset, label string) (string, error) {
-	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeNameFlag, metav1.GetOptions{})
+func getNodeLabelValueForNode(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	nodeName string,
+	label string,
+) (string, error) {
+	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("unable to get node object: %v", err)
 	}
@@ -571,16 +644,32 @@ func getNodeLabelValue(clientset *kubernetes.Clientset, label string) (string, e
 	return value, nil
 }
 
-func setNodeLabelValue(clientset *kubernetes.Clientset, label, value string) error {
-	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeNameFlag, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("unable to get node object: %v", err)
-	}
+func setNodeLabelValue(clientset kubernetes.Interface, label, value string) error {
+	return setNodeLabelValueForNode(context.TODO(), clientset, nodeNameFlag, label, value)
+}
 
-	labels := node.GetLabels()
-	labels[label] = value
-	node.SetLabels(labels)
-	_, err = clientset.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+func setNodeLabelValueForNode(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	nodeName string,
+	label string,
+	value string,
+) error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		labels := node.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[label] = value
+		node.SetLabels(labels)
+		_, err = clientset.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("unable to update node object: %v", err)
 	}

--- a/cmd/nvidia-k8s-vgpu-dm/main.go
+++ b/cmd/nvidia-k8s-vgpu-dm/main.go
@@ -358,7 +358,7 @@ func start(c *cli.Context) error {
 		}
 		vGPUConfigStateValue := getVGPUConfigStateValue(err)
 		log.Infof("Setting node label: %s=%s", vGPUConfigStateLabel, vGPUConfigStateValue)
-		_ = setNodeLabelValue(clientset, vGPUConfigStateLabel, vGPUConfigStateValue)
+		_ = setNodeLabelValueForNode(c.Context, clientset, nodeNameFlag, vGPUConfigStateLabel, vGPUConfigStateValue)
 		if c.Err() != nil {
 			return c.Err()
 		}
@@ -642,10 +642,6 @@ func getNodeLabelValueForNode(
 	}
 
 	return value, nil
-}
-
-func setNodeLabelValue(clientset kubernetes.Interface, label, value string) error {
-	return setNodeLabelValueForNode(context.TODO(), clientset, nodeNameFlag, label, value)
 }
 
 func setNodeLabelValueForNode(

--- a/cmd/nvidia-k8s-vgpu-dm/operand_labels.go
+++ b/cmd/nvidia-k8s-vgpu-dm/operand_labels.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+const pausedForVGPUChange = "paused-for-vgpu-change"
+
+type retryableConfigError struct {
+	err error
+}
+
+func (e *retryableConfigError) Error() string {
+	return e.err.Error()
+}
+
+func (e *retryableConfigError) Unwrap() error {
+	return e.err
+}
+
+func newRetryableConfigError(err error) error {
+	return &retryableConfigError{err: err}
+}
+
+func isRetryableConfigError(err error) bool {
+	var target *retryableConfigError
+	return errors.As(err, &target)
+}
+
+type operandPauseResult struct {
+	preexisting bool
+}
+
+func (r operandPauseResult) recovering() bool {
+	return r.preexisting
+}
+
+func pauseGPUOperandLabels(ctx context.Context, clientset kubernetes.Interface, nodeName string) (operandPauseResult, error) {
+	var result operandPauseResult
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		labels := node.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+
+		attempt := operandPauseResult{
+			preexisting: labels[pluginStateLabel] == pausedForVGPUChange ||
+				labels[validatorStateLabel] == pausedForVGPUChange,
+		}
+
+		changed := false
+		for _, key := range []string{pluginStateLabel, validatorStateLabel} {
+			value, exists := labels[key]
+			switch {
+			case !exists || value == "" || value == "false" || value == pausedForVGPUChange:
+				continue
+			case value == "true":
+				labels[key] = pausedForVGPUChange
+				changed = true
+			default:
+				return fmt.Errorf("cannot pause %q: label is owned by another operation with value %q", key, value)
+			}
+		}
+
+		if changed {
+			node.SetLabels(labels)
+			if _, err := clientset.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
+		}
+
+		result = attempt
+		return nil
+	})
+	if err != nil {
+		return operandPauseResult{}, fmt.Errorf("unable to pause GPU operand labels: %w", err)
+	}
+
+	return result, nil
+}
+
+func restoreGPUOperandLabels(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	nodeName string,
+	restorePlugin bool,
+	restoreValidator bool,
+) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		labels := node.GetLabels()
+		changed := false
+		if restorePlugin && labels[pluginStateLabel] == pausedForVGPUChange {
+			labels[pluginStateLabel] = "true"
+			changed = true
+		}
+		if restoreValidator && labels[validatorStateLabel] == pausedForVGPUChange {
+			labels[validatorStateLabel] = "true"
+			changed = true
+		}
+		if !changed {
+			return nil
+		}
+
+		node.SetLabels(labels)
+		_, err = clientset.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+		return err
+	})
+}

--- a/cmd/nvidia-k8s-vgpu-dm/operand_labels_test.go
+++ b/cmd/nvidia-k8s-vgpu-dm/operand_labels_test.go
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	testNodeName = "test-node"
+	testConfig   = "test-config"
+)
+
+type fakeConfigOperations struct {
+	assertValidFunc            func(string) error
+	assertAppliedFunc          func(string) error
+	applyFunc                  func(string) error
+	configureMIGFunc           func(string) error
+	waitForOperandShutdownFunc func(context.Context, string) error
+}
+
+func (o *fakeConfigOperations) assertValid(config string) error {
+	return o.assertValidFunc(config)
+}
+
+func (o *fakeConfigOperations) assertApplied(config string) error {
+	return o.assertAppliedFunc(config)
+}
+
+func (o *fakeConfigOperations) apply(config string) error {
+	return o.applyFunc(config)
+}
+
+func (o *fakeConfigOperations) configureMIG(config string) error {
+	return o.configureMIGFunc(config)
+}
+
+func (o *fakeConfigOperations) waitForOperandShutdown(ctx context.Context, labelSelector string) error {
+	return o.waitForOperandShutdownFunc(ctx, labelSelector)
+}
+
+func TestPauseGPUOperandLabelsUsesStrictTransitions(t *testing.T) {
+	testCases := []struct {
+		name             string
+		labels           map[string]string
+		expected         map[string]string
+		expectRecovery   bool
+		expectPauseError bool
+	}{
+		{
+			name: "enabled operands are paused",
+			labels: map[string]string{
+				pluginStateLabel:    "true",
+				validatorStateLabel: "true",
+			},
+			expected: map[string]string{
+				pluginStateLabel:    pausedForVGPUChange,
+				validatorStateLabel: pausedForVGPUChange,
+			},
+		},
+		{
+			name: "disabled and absent operands are preserved",
+			labels: map[string]string{
+				pluginStateLabel: "false",
+			},
+			expected: map[string]string{
+				pluginStateLabel: "false",
+			},
+		},
+		{
+			name: "owned pauses are idempotent",
+			labels: map[string]string{
+				pluginStateLabel:    pausedForVGPUChange,
+				validatorStateLabel: pausedForVGPUChange,
+			},
+			expected: map[string]string{
+				pluginStateLabel:    pausedForVGPUChange,
+				validatorStateLabel: pausedForVGPUChange,
+			},
+			expectRecovery: true,
+		},
+		{
+			name: "another operation's pause is preserved",
+			labels: map[string]string{
+				pluginStateLabel:    "paused-for-driver-upgrade",
+				validatorStateLabel: "true",
+			},
+			expected: map[string]string{
+				pluginStateLabel:    "paused-for-driver-upgrade",
+				validatorStateLabel: "true",
+			},
+			expectPauseError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := newTestClientset(t, testNode(tc.labels))
+
+			result, err := pauseGPUOperandLabels(context.Background(), clientset, testNodeName)
+			if tc.expectPauseError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectRecovery, result.recovering())
+			}
+
+			require.Equal(t, tc.expected, nodeLabels(t, clientset))
+		})
+	}
+}
+
+func TestRestoreGPUOperandLabelsRestoresOnlyOwnedPauses(t *testing.T) {
+	clientset := newTestClientset(t, testNode(map[string]string{
+		pluginStateLabel:    pausedForVGPUChange,
+		validatorStateLabel: "paused-for-driver-upgrade",
+		"unrelated":         "unchanged",
+	}))
+
+	err := restoreGPUOperandLabels(context.Background(), clientset, testNodeName, true, true)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		pluginStateLabel:    "true",
+		validatorStateLabel: "paused-for-driver-upgrade",
+		"unrelated":         "unchanged",
+	}, nodeLabels(t, clientset))
+}
+
+func TestUpdateConfigRecoversOwnedPausesWhenConfigIsAlreadyApplied(t *testing.T) {
+	clientset := newTestClientset(t, testNode(map[string]string{
+		vGPUConfigLabel:     testConfig,
+		pluginStateLabel:    pausedForVGPUChange,
+		validatorStateLabel: pausedForVGPUChange,
+	}))
+	reconciler, operations := testConfigReconciler(clientset)
+	operations.assertAppliedFunc = func(string) error { return nil }
+	operations.applyFunc = func(string) error {
+		t.Fatal("apply must not run when the requested configuration is already applied")
+		return nil
+	}
+
+	require.NoError(t, reconciler.updateConfig(context.Background(), testConfig))
+	require.Equal(t, "true", nodeLabels(t, clientset)[pluginStateLabel])
+	require.Equal(t, "true", nodeLabels(t, clientset)[validatorStateLabel])
+}
+
+func TestUpdateConfigApplyFailureRestoresGPUOperands(t *testing.T) {
+	clientset := newTestClientset(t, testNode(map[string]string{
+		vGPUConfigLabel:     testConfig,
+		pluginStateLabel:    "true",
+		validatorStateLabel: "true",
+	}))
+	reconciler, operations := testConfigReconciler(clientset)
+	operations.assertAppliedFunc = func(string) error { return errors.New("not applied") }
+	operations.applyFunc = func(string) error { return errors.New("apply failed") }
+
+	err := reconciler.updateConfig(context.Background(), testConfig)
+	require.ErrorContains(t, err, "apply failed")
+	require.False(t, isRetryableConfigError(err))
+	require.Equal(t, "true", nodeLabels(t, clientset)[pluginStateLabel])
+	require.Equal(t, "true", nodeLabels(t, clientset)[validatorStateLabel])
+}
+
+func TestUpdateConfigWithRetryUsesLatestDesiredConfig(t *testing.T) {
+	clientset := newTestClientset(t, testNode(map[string]string{
+		vGPUConfigLabel:     testConfig,
+		pluginStateLabel:    "true",
+		validatorStateLabel: "true",
+	}))
+	reconciler, operations := testConfigReconciler(clientset)
+
+	applied := false
+	var assertedConfigs []string
+	operations.assertValidFunc = func(config string) error {
+		assertedConfigs = append(assertedConfigs, config)
+		return nil
+	}
+	operations.assertAppliedFunc = func(string) error {
+		if applied {
+			return nil
+		}
+		return errors.New("not applied")
+	}
+	operations.applyFunc = func(string) error {
+		applied = true
+		return nil
+	}
+
+	waitCalls := 0
+	operations.waitForOperandShutdownFunc = func(ctx context.Context, _ string) error {
+		waitCalls++
+		if waitCalls != 1 {
+			return nil
+		}
+
+		node, err := clientset.CoreV1().Nodes().Get(ctx, testNodeName, metav1.GetOptions{})
+		require.NoError(t, err)
+		node.Labels[vGPUConfigLabel] = "new-config"
+		_, err = clientset.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		return errors.New("transient shutdown failure")
+	}
+
+	selectedConfig, err := updateConfigWithRetry(
+		context.Background(),
+		reconciler,
+		testConfig,
+		wait.Backoff{Steps: 2},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "new-config", selectedConfig)
+	require.Equal(t, []string{testConfig, "new-config"}, assertedConfigs)
+}
+
+func TestUpdateConfigWithRetryIsBounded(t *testing.T) {
+	clientset := newTestClientset(t, testNode(map[string]string{
+		vGPUConfigLabel:     testConfig,
+		pluginStateLabel:    "true",
+		validatorStateLabel: "true",
+	}))
+	reconciler, operations := testConfigReconciler(clientset)
+
+	attempts := 0
+	operations.assertValidFunc = func(string) error {
+		attempts++
+		return nil
+	}
+	operations.waitForOperandShutdownFunc = func(context.Context, string) error {
+		return errors.New("transient shutdown failure")
+	}
+
+	_, err := updateConfigWithRetry(
+		context.Background(),
+		reconciler,
+		testConfig,
+		wait.Backoff{Steps: 3},
+	)
+	require.ErrorContains(t, err, "transient shutdown failure")
+	require.True(t, isRetryableConfigError(err))
+	require.Equal(t, 3, attempts)
+}
+
+func TestUpdateConfigRestoresOperandsOnlyAfterExactVerification(t *testing.T) {
+	clientset := newTestClientset(t, testNode(map[string]string{
+		vGPUConfigLabel:     testConfig,
+		pluginStateLabel:    "true",
+		validatorStateLabel: "true",
+	}))
+	reconciler, operations := testConfigReconciler(clientset)
+	assertCalls := 0
+	operations.assertAppliedFunc = func(string) error {
+		assertCalls++
+		if assertCalls == 1 {
+			return errors.New("not applied")
+		}
+		return nil
+	}
+
+	require.NoError(t, reconciler.updateConfig(context.Background(), testConfig))
+	require.Equal(t, 2, assertCalls)
+	require.Equal(t, "true", nodeLabels(t, clientset)[pluginStateLabel])
+	require.Equal(t, "true", nodeLabels(t, clientset)[validatorStateLabel])
+}
+
+func TestUpdateConfigRestoresOperandsIfDesiredConfigChanges(t *testing.T) {
+	clientset := newTestClientset(t, testNode(map[string]string{
+		vGPUConfigLabel:     testConfig,
+		pluginStateLabel:    "true",
+		validatorStateLabel: "true",
+	}))
+	reconciler, operations := testConfigReconciler(clientset)
+	assertCalls := 0
+	operations.assertAppliedFunc = func(string) error {
+		assertCalls++
+		if assertCalls == 1 {
+			return errors.New("not applied")
+		}
+		return nil
+	}
+	operations.applyFunc = func(string) error {
+		node, err := clientset.CoreV1().Nodes().Get(context.Background(), testNodeName, metav1.GetOptions{})
+		require.NoError(t, err)
+		node.Labels[vGPUConfigLabel] = "new-config"
+		_, err = clientset.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		return nil
+	}
+
+	err := reconciler.updateConfig(context.Background(), testConfig)
+	require.ErrorContains(t, err, `vGPU config changed from "test-config" to "new-config"`)
+	require.True(t, isRetryableConfigError(err))
+	require.Equal(t, "true", nodeLabels(t, clientset)[pluginStateLabel])
+	require.Equal(t, "true", nodeLabels(t, clientset)[validatorStateLabel])
+}
+
+func TestShutdownFailureRollsBackOnlyNewlyAcquiredPause(t *testing.T) {
+	testCases := []struct {
+		name           string
+		initialPlugin  string
+		expectedPlugin string
+	}{
+		{
+			name:           "new pause is rolled back",
+			initialPlugin:  "true",
+			expectedPlugin: "true",
+		},
+		{
+			name:           "recovered pause remains",
+			initialPlugin:  pausedForVGPUChange,
+			expectedPlugin: pausedForVGPUChange,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := newTestClientset(t, testNode(map[string]string{
+				pluginStateLabel:    tc.initialPlugin,
+				validatorStateLabel: "true",
+			}))
+			reconciler, operations := testConfigReconciler(clientset)
+			operations.waitForOperandShutdownFunc = func(context.Context, string) error {
+				return errors.New("timed out")
+			}
+
+			_, err := reconciler.shutdownGPUOperands(context.Background())
+			require.ErrorContains(t, err, "timed out")
+			require.True(t, isRetryableConfigError(err))
+			require.Equal(t, tc.expectedPlugin, nodeLabels(t, clientset)[pluginStateLabel])
+			require.Equal(t, "true", nodeLabels(t, clientset)[validatorStateLabel])
+		})
+	}
+}
+
+func testConfigReconciler(clientset kubernetes.Interface) (*configReconciler, *fakeConfigOperations) {
+	operations := &fakeConfigOperations{
+		assertValidFunc:            func(string) error { return nil },
+		assertAppliedFunc:          func(string) error { return errors.New("not applied") },
+		applyFunc:                  func(string) error { return nil },
+		configureMIGFunc:           func(string) error { return nil },
+		waitForOperandShutdownFunc: func(context.Context, string) error { return nil },
+	}
+	reconciler := &configReconciler{
+		clientset:         clientset,
+		operations:        operations,
+		defaultVGPUConfig: "default",
+		nodeName:          testNodeName,
+	}
+	return reconciler, operations
+}
+
+func testNode(labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   testNodeName,
+			Labels: labels,
+		},
+	}
+}
+
+func nodeLabels(t *testing.T, clientset kubernetes.Interface) map[string]string {
+	t.Helper()
+	node, err := clientset.CoreV1().Nodes().Get(context.Background(), testNodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	return node.Labels
+}
+
+func newTestClientset(t *testing.T, node *corev1.Node) *kubernetes.Clientset {
+	t.Helper()
+
+	var mutex sync.Mutex
+	storedNode := node.DeepCopy()
+	storedNode.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "Node"}
+	storedNode.ResourceVersion = "1"
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case request.Method == http.MethodGet && request.URL.Path == "/api/v1/nodes/"+testNodeName:
+			mutex.Lock()
+			defer mutex.Unlock()
+			_ = json.NewEncoder(writer).Encode(storedNode)
+		case request.Method == http.MethodPut && request.URL.Path == "/api/v1/nodes/"+testNodeName:
+			var updated corev1.Node
+			if err := json.NewDecoder(request.Body).Decode(&updated); err != nil {
+				http.Error(writer, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			mutex.Lock()
+			storedNode = updated.DeepCopy()
+			mutex.Unlock()
+			_ = json.NewEncoder(writer).Encode(storedNode)
+		case request.Method == http.MethodGet &&
+			request.URL.Path == "/api/v1/namespaces/test-namespace/pods":
+			_ = json.NewEncoder(writer).Encode(&corev1.PodList{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "PodList"},
+			})
+		default:
+			http.Error(writer, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	clientset, err := kubernetes.NewForConfig(&rest.Config{
+		Host: server.URL,
+		ContentConfig: rest.ContentConfig{
+			AcceptContentTypes: "application/json",
+			ContentType:        "application/json",
+		},
+	})
+	require.NoError(t, err)
+	return clientset
+}

--- a/cmd/nvidia-k8s-vgpu-dm/reconfigure_mig.go
+++ b/cmd/nvidia-k8s-vgpu-dm/reconfigure_mig.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -169,7 +170,7 @@ func reconfigureMIG(clientset *kubernetes.Clientset, opts *reconfigureMIGOptions
 	if err := applyMIGModeOnly(opts); err != nil || assertMIGModeOnly(opts) != nil {
 		if opts.WithReboot {
 			log.Infof("Changing the '%s' node label to '%s'", vGPUConfigStateLabel, configStateRebooting)
-			if err := setNodeLabelValue(clientset, vGPUConfigStateLabel, configStateRebooting); err != nil {
+			if err := setNodeLabelValueForNode(context.TODO(), clientset, nodeNameFlag, vGPUConfigStateLabel, configStateRebooting); err != nil {
 				log.Errorf("Unable to set the value of '%s' to '%s'", vGPUConfigStateLabel, configStateRebooting)
 				log.Error("Exiting so as not to reboot multiple times unexpectedly")
 				return err

--- a/vendor/k8s.io/client-go/util/retry/OWNERS
+++ b/vendor/k8s.io/client-go/util/retry/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - caesarxuchao

--- a/vendor/k8s.io/client-go/util/retry/util.go
+++ b/vendor/k8s.io/client-go/util/retry/util.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DefaultRetry is the recommended retry for a conflict where multiple clients
+// are making changes to the same resource.
+var DefaultRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+// DefaultBackoff is the recommended backoff for a conflict where a client
+// may be attempting to make an unrelated modification to a resource under
+// active management by one or more controllers.
+var DefaultBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 10 * time.Millisecond,
+	Factor:   5.0,
+	Jitter:   0.1,
+}
+
+// OnError allows the caller to retry fn in case the error returned by fn is retriable
+// according to the provided function. backoff defines the maximum retries and the wait
+// interval between two retries.
+func OnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) error {
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case retriable(err):
+			lastErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if wait.Interrupted(err) {
+		err = lastErr
+	}
+	return err
+}
+
+// RetryOnConflict is used to make an update to a resource when you have to worry about
+// conflicts caused by other code making unrelated updates to the resource at the same
+// time. fn should fetch the resource to be modified, make appropriate changes to it, try
+// to update it, and return (unmodified) the error from the update function. On a
+// successful update, RetryOnConflict will return nil. If the update function returns a
+// "Conflict" error, RetryOnConflict will wait some amount of time as described by
+// backoff, and then try again. On a non-"Conflict" error, or if it retries too many times
+// and gives up, RetryOnConflict will return an error to the caller.
+//
+//	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+//	    // Fetch the resource here; you need to refetch it on every try, since
+//	    // if you got a conflict on the last update attempt then you need to get
+//	    // the current version before making your own changes.
+//	    pod, err := c.Pods("mynamespace").Get(name, metav1.GetOptions{})
+//	    if err != nil {
+//	        return err
+//	    }
+//
+//	    // Make whatever updates to the resource are needed
+//	    pod.Status.Phase = v1.PodFailed
+//
+//	    // Try to update
+//	    _, err = c.Pods("mynamespace").UpdateStatus(pod)
+//	    // You have to return err itself here (not wrapped inside another error)
+//	    // so that RetryOnConflict can identify it correctly.
+//	    return err
+//	})
+//	if err != nil {
+//	    // May be conflict if max retries were hit, or may be something unrelated
+//	    // like permissions or a network error
+//	    return err
+//	}
+//	...
+//
+// TODO: Make Backoff an interface?
+func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
+	return OnError(backoff, errors.IsConflict, fn)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -460,6 +460,7 @@ k8s.io/client-go/util/consistencydetector
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/keyutil
+k8s.io/client-go/util/retry
 k8s.io/client-go/util/watchlist
 k8s.io/client-go/util/workqueue
 # k8s.io/klog/v2 v2.140.0


### PR DESCRIPTION
Currently There are a few issues with the way we update config
1. We first disable the sandbox validator, wait for the pod to disappear and only then set up the defer function to restore the node labels, If the pod crashes after configuration is applied, then we can be stuck in a state where the sandbox pods are never re enabled.
2. if updateConfig function fails, we only log the error but we don't retry the operation. So a failed configuration apply needs to wait for another configuration update or a pod restart for the configuration to be re applied, which is not great user experience.

Restructring the code to make the workflow a little more resilient to such errors, this is in addition to the change in the [GPU operator ](https://github.com/NVIDIA/gpu-operator/pull/2857)to help with https://github.com/NVIDIA/gpu-operator/issues/2845 

TODO:

- [x] Test the changes against an actual machine with vGPUs